### PR TITLE
Add unit tests for Player and TicTacToe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,5 +21,14 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/test/java/org/example/PlayerTest.java
+++ b/src/test/java/org/example/PlayerTest.java
@@ -1,0 +1,21 @@
+package org.example;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlayerTest {
+
+    @Test
+    void testGetMarkerX() {
+        Player player = new Player('X');
+        assertEquals('X', player.getMarker());
+    }
+
+    @Test
+    void testGetMarkerO() {
+        Player player = new Player('O');
+        assertEquals('O', player.getMarker());
+    }
+
+}

--- a/src/test/java/org/example/TicTacToeTest.java
+++ b/src/test/java/org/example/TicTacToeTest.java
@@ -1,0 +1,40 @@
+package org.example;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TicTacToeTest {
+    private TicTacToe game;
+
+    @BeforeEach
+    void setUp() {
+        game = new TicTacToe();
+    }
+
+    @Test
+    void testInitialCurrentPlayer() throws Exception {
+        Field currentPlayerField = TicTacToe.class.getDeclaredField("currentPlayer");
+        currentPlayerField.setAccessible(true);
+        Player current = (Player) currentPlayerField.get(game);
+        assertEquals('X', current.getMarker());
+    }
+
+    @Test
+    void testSwitchCurrentPlayer() throws Exception {
+        Field currentPlayerField = TicTacToe.class.getDeclaredField("currentPlayer");
+        currentPlayerField.setAccessible(true);
+        Method switchMethod = TicTacToe.class.getDeclaredMethod("switchCurrentPlayer");
+        switchMethod.setAccessible(true);
+
+        Player before = (Player) currentPlayerField.get(game);
+        switchMethod.invoke(game);
+        Player after = (Player) currentPlayerField.get(game);
+
+        assertNotEquals(before.getMarker(), after.getMarker());
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit tests covering `Player` markers
- add JUnit tests for `TicTacToe` using reflection
- enable surefire plugin in `pom.xml`

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867b4786fac83238d3c11cc87e22a88