### PR TITLE
Updated pom.xml to make maven use the right main class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,5 +21,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+         
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.3.0</version>
+            <configuration>
+                <archive>
+                    <manifest>
+                        <mainClass>org.example.Main</mainClass>
+                    </manifest>
+                </archive>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
 
 </project>


### PR DESCRIPTION
Configured the maven-jar-plugin in pom.xml to specify the main class inside the .jar.

This way, maven can build an executable .jar file which can be run with: 
 java -jar SLT-SS25-TicTacToe_GroupC-1.0-SNAPSHOT.jar.

Previously, the user had to manually specify the main class.